### PR TITLE
Generic Opensearchable with default mime type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Terradue.OpenSearch.userprefs
 /Terradue.OpenSearch/obj
 /packages/
 /packages
+
+/Terradue.OpenSearch.Test/bin/

--- a/Terradue.OpenSearch.Test/GenericTest.cs
+++ b/Terradue.OpenSearch.Test/GenericTest.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using NUnit.Framework;
+using Terradue.OpenSearch.Engine;
+using Mono.Addins;
+using Terradue.OpenSearch.Result;
+using Terradue.OpenSearch.Engine;
+
+namespace Terradue.OpenSearch.RdfEO.Test {
+
+    [TestFixture()]
+    public class GenericTest {
+
+        [Test()]
+        public void GenericOpenSearchableTest() {
+
+            AddinManager.Initialize();
+            AddinManager.Registry.Update(null);
+
+            OpenSearchEngine ose = new OpenSearchEngine();
+
+            ose.LoadPlugins();
+            OpenSearchUrl url = new OpenSearchUrl("http://catalogue.terradue.int/catalogue/search/MER_FRS_1P/rdf?startIndex=0&q=MER_FRS_1P&start=1992-01-01&stop=2014-10-24&bbox=-72,47,-57,58");
+            IOpenSearchable entity = new GenericOpenSearchable(url, ose);
+
+            var osr = ose.Query(entity, new System.Collections.Specialized.NameValueCollection(), "rdf");
+
+            Assert.That(osr.Result.Links.Count > 0);
+
+        }
+    }
+}
+

--- a/Terradue.OpenSearch.Test/Terradue.OpenSearch.Test.csproj
+++ b/Terradue.OpenSearch.Test/Terradue.OpenSearch.Test.csproj
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Terradue.OpenSearch.Test</RootNamespace>
+    <AssemblyName>Terradue.OpenSearch.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Addins">
+      <HintPath>..\packages\Mono.Addins.1.1\lib\Mono.Addins.dll</HintPath>
+    </Reference>
+    <Reference Include="Terradue.ServiceModel.Syndication">
+      <HintPath>..\packages\Terradue.ServiceModel.Syndication.1.0.0.0\lib\net40\Terradue.ServiceModel.Syndication.dll</HintPath>
+    </Reference>
+    <Reference Include="ServiceStack.Text">
+      <HintPath>..\packages\ServiceStack.Text.3.9.71\lib\net35\ServiceStack.Text.dll</HintPath>
+    </Reference>
+    <Reference Include="Terradue.GeoJson">
+      <HintPath>..\packages\Terradue.GeoJson.1.4.0\lib\net40\Terradue.GeoJson.dll</HintPath>
+    </Reference>
+    <Reference Include="Terradue.OpenSearch.RdfEO">
+      <HintPath>..\packages\Terradue.OpenSearch.RdfEO.1.0.2\lib\net40\Terradue.OpenSearch.RdfEO.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Test.cs" />
+    <Compile Include="GenericTest.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Terradue.OpenSearch\Terradue.OpenSearch.csproj">
+      <Project>{997A44FD-EE4A-490A-855B-88305E0CD269}</Project>
+      <Name>Terradue.OpenSearch</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Terradue.OpenSearch.Test/Test.cs
+++ b/Terradue.OpenSearch.Test/Test.cs
@@ -1,0 +1,12 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace Terradue.OpenSearch.Test {
+    [TestFixture()]
+    public class Test {
+        [Test()]
+        public void TestCase() {
+        }
+    }
+}
+

--- a/Terradue.OpenSearch.Test/packages.config
+++ b/Terradue.OpenSearch.Test/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Addins" version="1.1" targetFramework="net45" />
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="ServiceStack.Text" version="3.9.71" targetFramework="net45" />
+  <package id="Terradue.GeoJson" version="1.4.0" targetFramework="net45" />
+  <package id="Terradue.OpenSearch" version="1.7.0" targetFramework="net45" />
+  <package id="Terradue.OpenSearch.RdfEO" version="1.0.2" targetFramework="net45" />
+  <package id="Terradue.ServiceModel.Syndication" version="1.0.0.0" targetFramework="net45" />
+</packages>

--- a/Terradue.OpenSearch.sln
+++ b/Terradue.OpenSearch.sln
@@ -3,12 +3,18 @@ Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terradue.OpenSearch", "Terradue.OpenSearch\Terradue.OpenSearch.csproj", "{997A44FD-EE4A-490A-855B-88305E0CD269}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terradue.OpenSearch.Test", "Terradue.OpenSearch.Test\Terradue.OpenSearch.Test.csproj", "{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10E8EBF3-FD2C-4CFF-843C-6781BA1DE573}.Release|Any CPU.Build.0 = Release|Any CPU
 		{997A44FD-EE4A-490A-855B-88305E0CD269}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{997A44FD-EE4A-490A-855B-88305E0CD269}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{997A44FD-EE4A-490A-855B-88305E0CD269}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/Terradue.OpenSearch/Terradue/OpenSearch/OpenSearchable/GenericOpenSearchable.cs
+++ b/Terradue.OpenSearch/Terradue/OpenSearch/OpenSearchable/GenericOpenSearchable.cs
@@ -52,7 +52,7 @@ namespace Terradue.OpenSearch {
         #region IOpenSearchable implementation
 
         public QuerySettings GetQuerySettings(OpenSearchEngine ose) {
-            IOpenSearchEngineExtension osee = ose.GetExtensionByContentTypeAbility(GetOpenSearchDescription().ContentTypes);
+            IOpenSearchEngineExtension osee = ose.GetExtensionByContentTypeAbility(this.DefaultMimeType);
             if (osee == null) return null;
 
             return new QuerySettings(osee.DiscoveryContentType, osee.ReadNative);


### PR DESCRIPTION
When instantiating a GenericOpensearchable from a open search url, the initial mime type was forgotten. Now it is taken into account as default url template

Signed-off-by: Emmanuel Mathot emmanuel.mahot@gmail.com
